### PR TITLE
add optional version number to constructor

### DIFF
--- a/lib/live-event.js
+++ b/lib/live-event.js
@@ -3,6 +3,7 @@ const resource = require('./resource');
 class LiveEvent extends resource.Resource {
   constructor(elementalClient) {
     super(elementalClient, 'live_events');
+    this.version = elementalClient.version ? `${elementalClient.version}/` : '';
 
     // these operations are mapped to methods named <operation>Event, that
     // modifies the event. For example: startEvent, stopEvent and resetEvent.
@@ -14,31 +15,31 @@ class LiveEvent extends resource.Resource {
   // the status endpoint for a live event provides additional undocumented information like audio_level
   // when the Accept header is set to application/json
   eventStatus(eventId, headers = null) {
-    return this.elementalClient.sendRequest('GET', `/api/live_events/${eventId}/status`, null, null, headers);
+    return this.elementalClient.sendRequest('GET', `/api/${this.version}live_events/${eventId}/status`, null, null, headers);
   }
 
   listInputs(eventId) {
-    return this.elementalClient.sendRequest('GET', `/api/live_events/${eventId}/inputs`);
+    return this.elementalClient.sendRequest('GET', `/api/${this.version}live_events/${eventId}/inputs`);
   }
 
   muteEvent(eventId) {
-    return this.elementalClient.sendRequest('POST', `/api/live_events/${eventId}/mute_audio`);
+    return this.elementalClient.sendRequest('POST', `/api/${this.version}live_events/${eventId}/mute_audio`);
   }
 
   unmuteEvent(eventId) {
-    return this.elementalClient.sendRequest('POST', `/api/live_events/${eventId}/unmute_audio`);
+    return this.elementalClient.sendRequest('POST', `/api/${this.version}live_events/${eventId}/unmute_audio`);
   }
 
   adjustAudioGain(eventId, gain) {
-    return this.elementalClient.sendRequest('POST', `/api/live_events/${eventId}/adjust_audio_gain`, null, {gain});
+    return this.elementalClient.sendRequest('POST', `/api/${this.version}live_events/${eventId}/adjust_audio_gain`, null, {gain});
   }
 
   eventPriority(eventId) {
-    return this.elementalClient.sendRequest('GET', `/api/live_events/${eventId}/priority`);
+    return this.elementalClient.sendRequest('GET', `/api/${this.version}live_events/${eventId}/priority`);
   }
 
   setEventPriority(eventId, priority) {
-    return this.elementalClient.sendRequest('POST', `/api/live_events/${eventId}/priority`, null, {priority});
+    return this.elementalClient.sendRequest('POST', `/api/${this.version}live_events/${eventId}/priority`, null, {priority});
   }
 
   eventProgressPreview(eventId) {
@@ -46,7 +47,7 @@ class LiveEvent extends resource.Resource {
   }
 
   activateInput(eventId, input_id) {
-    return this.elementalClient.sendRequest('POST', `/api/live_events/${eventId}/activate_input`, null, {input_id});
+    return this.elementalClient.sendRequest('POST', `/api/${this.version}live_events/${eventId}/activate_input`, null, {input_id});
   }
 }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -7,7 +7,7 @@ const LiveEvent = require('./live-event').LiveEvent;
 const Resource = require('./resource').Resource;
 
 class ElementalClient {
-  constructor(serverUrl, extraHeaders) {
+  constructor(serverUrl, extraHeaders, version = null) {
     const headers = extraHeaders || {};
 
     headers.Accept = 'application/xml';
@@ -16,6 +16,7 @@ class ElementalClient {
       baseUrl: serverUrl,
     });
     this.serverUrl = serverUrl.replace(/\/+$/, '');
+    this.version = version;
 
     const resourceMap = {
       'presets': 'presets',

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -2,26 +2,27 @@ class Resource {
   constructor(elementalClient, name) {
     this.elementalClient = elementalClient;
     this.name = name;
+    this.version = elementalClient.version ? `${elementalClient.version}/` : '';
   }
 
   create(opts) {
-    return this.elementalClient.sendRequest('POST', `/api/${this.name}`, null, opts);
+    return this.elementalClient.sendRequest('POST', `/api/${this.version}${this.name}`, null, opts);
   }
 
   retrieve(id) {
-    return this.elementalClient.sendRequest('GET', `/api/${this.name}/${id}`);
+    return this.elementalClient.sendRequest('GET', `/api/${this.version}${this.name}/${id}`);
   }
 
   update(id, opts) {
-    return this.elementalClient.sendRequest('PUT', `/api/${this.name}/${id}`, null, opts);
+    return this.elementalClient.sendRequest('PUT', `/api/${this.version}${this.name}/${id}`, null, opts);
   }
 
   delete(id) {
-    return this.elementalClient.sendRequest('DELETE', `/api/${this.name}/${id}`);
+    return this.elementalClient.sendRequest('DELETE', `/api/${this.version}${this.name}/${id}`);
   }
 
   list(opts) {
-    return this.elementalClient.sendRequest('GET', `/api/${this.name}`, opts);
+    return this.elementalClient.sendRequest('GET', `/api/${this.version}${this.name}`, opts);
   }
 }
 

--- a/test/resource-test.js
+++ b/test/resource-test.js
@@ -5,6 +5,8 @@ import sinon from 'sinon';
 describe('Resource', () => {
   const resourceName = 'stuff';
   const resourceUrl = '/api/stuff';
+  const dummyVersion = '2.14'
+  const versionedUrl = `/api/${dummyVersion}/stuff`;
   const retval = {key: 'value'};
   let client = {};
 
@@ -21,12 +23,31 @@ describe('Resource', () => {
     assert(client.sendRequest.calledWith('POST', resourceUrl, null, data))
   });
 
+  it('create with version', () => {
+    client.version = dummyVersion;
+    const resource = new Resource(client, resourceName);
+    const data = {name: 'Some stuff', description: 'Best stuff ever!'};
+    const result = resource.create(data);
+
+    assert.equal(result, retval);
+    assert(client.sendRequest.calledWith('POST', versionedUrl, null, data))
+  });
+
   it('retrieve', () => {
     const resource = new Resource(client, resourceName);
     const result = resource.retrieve(10);
 
     assert.equal(result, retval);
     assert(client.sendRequest.calledWith('GET', `${resourceUrl}/10`))
+  });
+
+  it('retrieve with version', () => {
+    client.version = dummyVersion;
+    const resource = new Resource(client, resourceName);
+    const result = resource.retrieve(10);
+
+    assert.equal(result, retval);
+    assert(client.sendRequest.calledWith('GET', `${versionedUrl}/10`))
   });
 
   it('update', () => {
@@ -38,6 +59,16 @@ describe('Resource', () => {
     assert(client.sendRequest.calledWith('PUT', `${resourceUrl}/10`, null, data))
   });
 
+  it('update with version', () => {
+    client.version = dummyVersion;
+    const resource = new Resource(client, resourceName);
+    const data = {description: 'Stuff number 10 (is this binary or decimal?)'}
+    const result = resource.update(10, data);
+
+    assert.equal(result, retval);
+    assert(client.sendRequest.calledWith('PUT', `${versionedUrl}/10`, null, data))
+  });
+
   it('delete', () => {
     const resource = new Resource(client, resourceName);
     const result = resource.delete(10);
@@ -46,11 +77,29 @@ describe('Resource', () => {
     assert(client.sendRequest.calledWith('DELETE', `${resourceUrl}/10`))
   });
 
+  it('delete with version', () => {
+    client.version = dummyVersion;
+    const resource = new Resource(client, resourceName);
+    const result = resource.delete(10);
+
+    assert.equal(result, retval);
+    assert(client.sendRequest.calledWith('DELETE', `${versionedUrl}/10`))
+  });
+
   it('list', () => {
     const resource = new Resource(client, resourceName);
     const result = resource.list({page: 1});
 
     assert.equal(result, retval);
     assert(client.sendRequest.calledWith('GET', resourceUrl, {page: 1}))
+  });
+
+  it('list with version', () => {
+    client.version = dummyVersion;
+    const resource = new Resource(client, resourceName);
+    const result = resource.list({page: 1});
+
+    assert.equal(result, retval);
+    assert(client.sendRequest.calledWith('GET', versionedUrl, {page: 1}))
   });
 });


### PR DESCRIPTION
This PR allows the user of this library to provide a version number when constructing an `ElementalClient` so all calls to the api will have that version number included.

For example, calling:

```
const client = new ElementalClient('https://elemental-server.example.com', { 'X-API-Key': 'aSecretKey' }, 'v2.15.3.0');
client.presets().create({...}).then(console.log);
```

Would make a POST request to `https://elemental-server.example.com/api/v2.15.3.0/presets` and log the output to the console.

This allows the user of this library to upgrade the software on an Elemental server without fear of API changes breaking existing workflows.