### PR TITLE
add required failure_rule to integration test

### DIFF
--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -47,6 +47,10 @@ describe('integration tests', () => {
             'uri': fileInput,
           },
         },
+        'failure_rule': {
+          'priority': '50',
+          'restart_on_failure': 'false',
+        },
         'stream_assembly': [
           {
             'name': 'stream1',


### PR DESCRIPTION
When I was running the integration tests last week, I was running in the following error on the live event creation integration test:

```
<?xml version="1.0" encoding="UTF-8"?>
<errors>
  <error>Failure rule can't be blank</error>
</errors>
```

Adding this failure rule allows for the event to be created. I'm still running into an error where resetting the event is not permitted, but that should probably be addressed in a separate PR.

For reference, this was tested against version `v2.13.6` of the API.