### PR TITLE
always accept application/xml unless explicitly overridden

### DIFF
--- a/lib/live-event.js
+++ b/lib/live-event.js
@@ -1,5 +1,4 @@
 const resource = require('./resource');
-const headers = {'Accept': 'application/json'};
 
 class LiveEvent extends resource.Resource {
   constructor(elementalClient) {
@@ -12,7 +11,9 @@ class LiveEvent extends resource.Resource {
     });
   }
 
-  eventStatus(eventId) {
+  // the status endpoint for a live event provides additional undocumented information like audio_level
+  // when the Accept header is set to application/json
+  eventStatus(eventId, headers = null) {
     return this.elementalClient.sendRequest('GET', `/api/live_events/${eventId}/status`, null, null, headers);
   }
 

--- a/test/live-event-test.js
+++ b/test/live-event-test.js
@@ -35,8 +35,16 @@ describe('LiveEvent', () => {
     const result = testData.instance.eventStatus(199);
 
     assert.equal(result, testData.retval);
+    assert(testData.sendRequest.calledWith('GET', '/api/live_events/199/status'));
+  });
+
+  it('eventStatus should allow for optional headers to be provided', () => {
+    const testData = getInstance();
+    const result = testData.instance.eventStatus(199, {'Accept': 'application/json'});
+
+    assert.equal(result, testData.retval);
     assert(testData.sendRequest.calledWith('GET', '/api/live_events/199/status', null, null, {'Accept': 'application/json'}));
-  })
+  });
 
   it('startEvent should send request to start event', () => {
     const testData = getInstance();


### PR DESCRIPTION
This PR makes the default `Accept` header for `/api/live_events/<event_id>/status` be `application/xml` so that the behavior of this library matches the documentation.

It also adds for an optional `headers` parameter, which allows us to request json, and explains in a comment why we might want to do that. It also adds a unit test for this use case.

Note: this is breaking change.