### PR TITLE
Only include version number in URL for PUT and POST requests

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -41,7 +41,7 @@ class Device extends resource.Resource {
       },
     };
 
-    return this.elementalClient.sendRequest('POST', `/api/devices/${opts.id}/preview`, null, data).
+    return this.elementalClient.sendRequest('POST', `/devices/${opts.id}/preview`, null, data).
       then((respData) => respData.preview_images.preview_image);
   }
 

--- a/lib/device.js
+++ b/lib/device.js
@@ -1,17 +1,5 @@
 const resource = require('./resource');
 
-const queryString = (object) => {
-  const parts = [];
-
-  for (const key in object) {
-    if (Reflect.apply(Object.prototype.hasOwnProperty, object, [key])) {
-      parts.push(`${key}=${object[key]}`);
-    }
-  }
-
-  return parts.join('&');
-};
-
 class Device extends resource.Resource {
   constructor(elementalClient) {
     super(elementalClient, 'devices');
@@ -43,29 +31,6 @@ class Device extends resource.Resource {
 
     return this.elementalClient.sendRequest('POST', `/devices/${opts.id}/preview`, null, data).
       then((respData) => respData.preview_images.preview_image);
-  }
-
-  generatePreview(opts) {
-    if (!opts.id) {
-      throw new Error('missing device id');
-    }
-    if (!opts.sourceType) {
-      throw new Error('missing source type');
-    }
-
-    const inputData = {
-      'input_key': 0,
-      'live_event[inputs_attributes][0][source_type]': opts.sourceType,
-      'live_event[inputs_attributes][0][device_input_attributes][sdi_settings_attributes][input_format]': 'Auto',
-      'live_event[inputs_attributes][0][device_input_attributes][device_id]': opts.id,
-    };
-    const body = queryString(inputData);
-    const headers = {
-      'Accept': '*/*',
-      'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
-    };
-
-    return this.elementalClient.sendRequest('POST', '/inputs/generate_preview', null, body, headers);
   }
 }
 

--- a/lib/live-event.js
+++ b/lib/live-event.js
@@ -3,43 +3,42 @@ const resource = require('./resource');
 class LiveEvent extends resource.Resource {
   constructor(elementalClient) {
     super(elementalClient, 'live_events');
-    this.version = elementalClient.version ? `${elementalClient.version}/` : '';
 
     // these operations are mapped to methods named <operation>Event, that
     // modifies the event. For example: startEvent, stopEvent and resetEvent.
     ['start', 'stop', 'cancel', 'archive', 'reset'].forEach((opName) => {
-      this[`${opName}Event`] = (eventId) => this.elementalClient.sendRequest('POST', `/api/live_events/${eventId}/${opName}`);
+      this[`${opName}Event`] = (eventId) => this.elementalClient.sendRequest('POST', `/live_events/${eventId}/${opName}`);
     });
   }
 
   // the status endpoint for a live event provides additional undocumented information like audio_level
   // when the Accept header is set to application/json
   eventStatus(eventId, headers = null) {
-    return this.elementalClient.sendRequest('GET', `/api/${this.version}live_events/${eventId}/status`, null, null, headers);
+    return this.elementalClient.sendRequest('GET', `/live_events/${eventId}/status`, null, null, headers);
   }
 
   listInputs(eventId) {
-    return this.elementalClient.sendRequest('GET', `/api/${this.version}live_events/${eventId}/inputs`);
+    return this.elementalClient.sendRequest('GET', `/live_events/${eventId}/inputs`);
   }
 
   muteEvent(eventId) {
-    return this.elementalClient.sendRequest('POST', `/api/${this.version}live_events/${eventId}/mute_audio`);
+    return this.elementalClient.sendRequest('POST', `/live_events/${eventId}/mute_audio`);
   }
 
   unmuteEvent(eventId) {
-    return this.elementalClient.sendRequest('POST', `/api/${this.version}live_events/${eventId}/unmute_audio`);
+    return this.elementalClient.sendRequest('POST', `/live_events/${eventId}/unmute_audio`);
   }
 
   adjustAudioGain(eventId, gain) {
-    return this.elementalClient.sendRequest('POST', `/api/${this.version}live_events/${eventId}/adjust_audio_gain`, null, {gain});
+    return this.elementalClient.sendRequest('POST', `/live_events/${eventId}/adjust_audio_gain`, null, {gain});
   }
 
   eventPriority(eventId) {
-    return this.elementalClient.sendRequest('GET', `/api/${this.version}live_events/${eventId}/priority`);
+    return this.elementalClient.sendRequest('GET', `/live_events/${eventId}/priority`);
   }
 
   setEventPriority(eventId, priority) {
-    return this.elementalClient.sendRequest('POST', `/api/${this.version}live_events/${eventId}/priority`, null, {priority});
+    return this.elementalClient.sendRequest('POST', `/live_events/${eventId}/priority`, null, {priority});
   }
 
   eventProgressPreview(eventId) {
@@ -47,7 +46,7 @@ class LiveEvent extends resource.Resource {
   }
 
   activateInput(eventId, input_id) {
-    return this.elementalClient.sendRequest('POST', `/api/${this.version}live_events/${eventId}/activate_input`, null, {input_id});
+    return this.elementalClient.sendRequest('POST', `/live_events/${eventId}/activate_input`, null, {input_id});
   }
 }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -34,7 +34,8 @@ class ElementalClient {
 
   sendRequest(method, path, qs, data, headers) {
     const reqHeaders = headers || {};
-    const url = path;
+    const url = this.version && ['PUT', 'POST'].includes(method)
+      ? `/api/${this.version}${path}` : `/api${path}`;
 
     return new Promise((resolve, reject) => {
       let reqBody = null;

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -2,27 +2,26 @@ class Resource {
   constructor(elementalClient, name) {
     this.elementalClient = elementalClient;
     this.name = name;
-    this.version = elementalClient.version ? `${elementalClient.version}/` : '';
   }
 
   create(opts) {
-    return this.elementalClient.sendRequest('POST', `/api/${this.version}${this.name}`, null, opts);
+    return this.elementalClient.sendRequest('POST', `/${this.name}`, null, opts);
   }
 
   retrieve(id) {
-    return this.elementalClient.sendRequest('GET', `/api/${this.version}${this.name}/${id}`);
+    return this.elementalClient.sendRequest('GET', `/${this.name}/${id}`);
   }
 
   update(id, opts) {
-    return this.elementalClient.sendRequest('PUT', `/api/${this.version}${this.name}/${id}`, null, opts);
+    return this.elementalClient.sendRequest('PUT', `/${this.name}/${id}`, null, opts);
   }
 
   delete(id) {
-    return this.elementalClient.sendRequest('DELETE', `/api/${this.version}${this.name}/${id}`);
+    return this.elementalClient.sendRequest('DELETE', `/${this.name}/${id}`);
   }
 
   list(opts) {
-    return this.elementalClient.sendRequest('GET', `/api/${this.version}${this.name}`, opts);
+    return this.elementalClient.sendRequest('GET', `/${this.name}`, opts);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elemental-live-client",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "JS library to communicate with Elemental live API",
   "directories": {
     "lib": "./lib"

--- a/test/device-test.js
+++ b/test/device-test.js
@@ -30,7 +30,7 @@ describe('Device', () => {
 
     return dvc.preview({id: 123, name: 'device-123-preview.jpg', width: 854, height: 480}).then((data) => {
       assert.deepEqual(data, previewImage);
-      assert(sendRequest.calledWith('POST', '/api/devices/123/preview', null, {
+      assert(sendRequest.calledWith('POST', '/devices/123/preview', null, {
         'preview_images': {
           'preview_image': {
             width: 854,

--- a/test/device-test.js
+++ b/test/device-test.js
@@ -65,27 +65,4 @@ describe('Device', () => {
       test({id: '123', name: 'some-preview', width: 1280}, 'missing preview height');
     });
   });
-
-  describe('generate preview', () => {
-    const retval = {};
-    const sendRequest = sinon.stub().returns(retval);
-    const dvc = new Device({sendRequest});
-    const result = dvc.generatePreview({id: '10', sourceType: 'DeviceInput,2,1,AJA,HD-SDI'});
-    const expectedBody = 'input_key=0&live_event[inputs_attributes][0][source_type]=DeviceInput,2,1,AJA,HD-SDI&live_event[inputs_attributes][0][device_input_attributes][sdi_settings_attributes][input_format]=Auto&live_event[inputs_attributes][0][device_input_attributes][device_id]=10';
-    const expectedHeaders = {
-      Accept: '*/*',
-      'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
-    };
-
-    assert.equal(result, retval);
-    assert(sendRequest.calledOnce);
-
-    const args = sendRequest.getCall(0).args;
-
-    assert.equal(args[0], 'POST');
-    assert.equal(args[1], '/inputs/generate_preview');
-    assert.equal(args[2], null);
-    assert.equal(args[3], expectedBody);
-    assert.deepEqual(args[4], expectedHeaders);
-  });
 });

--- a/test/elemental-client-test.js
+++ b/test/elemental-client-test.js
@@ -98,6 +98,63 @@ describe('ElementalClient', () => {
     );
   });
 
+  it('sendRequest should not include version number in GET requests', () => {
+    const client = new ElementalClient('http://my-elemental-server', null, 'v2.17.3.0');
+    const eventList = {'live_event_list': {
+      'live_event': [
+        {
+          '$': {href: '/live_events/1'},
+          name: 'Event 1',
+          input: {name: 'input_1'},
+        },
+        {
+          '$': {href: '/live_events/2'},
+          name: 'Event 2',
+          input: {name: 'input_1'},
+        },
+      ],
+    }};
+
+    client.req = (opts, callback) => {
+      assert.deepEqual(opts, {
+        method: 'GET',
+        url: '/api/live_events',
+        qs: null,
+        headers: {},
+        body: null,
+      });
+      callback(null, {statusCode: 200, headers: {'content-type': 'application/xml'}}, xmlEventList);
+    };
+
+    return client.sendRequest('GET', '/live_events', null).then(
+      (data) => {
+        assert.deepEqual(data, eventList);
+      }
+    );
+  });
+
+  it('sendRequest should include version number in PUT requests', () => {
+    const client = new ElementalClient('http://my-elemental-server', null, 'v2.17.3.0');
+    const body = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><name>My live event!</name>';
+
+    client.req = (opts, callback) => {
+      assert.deepEqual(opts, {
+        method: 'PUT',
+        url: '/api/v2.17.3.0/live_events/5',
+        qs: null,
+        headers: {'Content-Type': 'application/xml'},
+        body,
+      });
+      callback(null, {statusCode: 200, headers: {'content-type': 'application/xml'}}, body);
+    };
+
+    return client.sendRequest('PUT', '/live_events/5', null, {name: 'My live event!'}).then(
+      (data) => {
+        assert.deepEqual(data, {name: 'My live event!'});
+      }
+    );
+  });
+
   it('sendRequest should reject promise on request errors', (done) => {
     const client = new ElementalClient('http://my-elemental-server');
 

--- a/test/elemental-client-test.js
+++ b/test/elemental-client-test.js
@@ -22,7 +22,7 @@ describe('ElementalClient', () => {
       callback(null, {statusCode: 200, headers: {}}, eventList);
     };
 
-    return client.sendRequest('GET', '/api/live_events', {page: '3', 'per_page': 30}, null).
+    return client.sendRequest('GET', '/live_events', {page: '3', 'per_page': 30}, null).
       then((data) => {
         assert.deepEqual(data, eventList);
       });
@@ -56,7 +56,7 @@ describe('ElementalClient', () => {
       callback(null, {statusCode: 200, headers: {'content-type': 'application/xml'}}, xmlEventList);
     };
 
-    return client.sendRequest('POST', '/api/live_events', null, 'some nice data', {'Content-Type': 'text/plain'}).then(
+    return client.sendRequest('POST', '/live_events', null, 'some nice data', {'Content-Type': 'text/plain'}).then(
       (data) => {
         assert.deepEqual(data, eventList);
       }
@@ -91,7 +91,7 @@ describe('ElementalClient', () => {
       callback(null, {statusCode: 200, headers: {'content-type': 'application/xml'}}, xmlEventList);
     };
 
-    return client.sendRequest('POST', '/api/live_events', null, {name: 'My live event!'}).then(
+    return client.sendRequest('POST', '/live_events', null, {name: 'My live event!'}).then(
       (data) => {
         assert.deepEqual(data, eventList);
       }
@@ -105,7 +105,7 @@ describe('ElementalClient', () => {
       callback({error: 'failed to resolve name'});
     };
 
-    client.sendRequest('GET', '/api/live_events/1233', null, null).then(
+    client.sendRequest('GET', '/live_events/1233', null, null).then(
       () => assert(false),
       (reason) => {
         assert.deepEqual(reason, {error: 'failed to resolve name'});
@@ -121,7 +121,7 @@ describe('ElementalClient', () => {
       callback(null, {statusCode: 404}, {'errors': []});
     };
 
-    client.sendRequest('GET', '/api/live_events/1233', null, null).then(
+    client.sendRequest('GET', '/live_events/1233', null, null).then(
       () => assert(false),
       (reason) => {
         assert.equal(reason.statusCode, 404);

--- a/test/live-event-test.js
+++ b/test/live-event-test.js
@@ -27,7 +27,7 @@ describe('LiveEvent', () => {
     const result = testData.instance.listInputs(199);
 
     assert.equal(result, testData.retval);
-    assert(testData.sendRequest.calledWith('GET', '/api/live_events/199/inputs'));
+    assert(testData.sendRequest.calledWith('GET', '/live_events/199/inputs'));
   });
 
   it('eventStatus should retrieve the status of an event', () => {
@@ -35,7 +35,7 @@ describe('LiveEvent', () => {
     const result = testData.instance.eventStatus(199);
 
     assert.equal(result, testData.retval);
-    assert(testData.sendRequest.calledWith('GET', '/api/live_events/199/status'));
+    assert(testData.sendRequest.calledWith('GET', '/live_events/199/status'));
   });
 
   it('eventStatus should allow for optional headers to be provided', () => {
@@ -43,7 +43,7 @@ describe('LiveEvent', () => {
     const result = testData.instance.eventStatus(199, {'Accept': 'application/json'});
 
     assert.equal(result, testData.retval);
-    assert(testData.sendRequest.calledWith('GET', '/api/live_events/199/status', null, null, {'Accept': 'application/json'}));
+    assert(testData.sendRequest.calledWith('GET', '/live_events/199/status', null, null, {'Accept': 'application/json'}));
   });
 
   it('startEvent should send request to start event', () => {
@@ -51,7 +51,7 @@ describe('LiveEvent', () => {
     const result = testData.instance.startEvent(195);
 
     assert.equal(result, testData.retval);
-    assert(testData.sendRequest.calledWith('POST', '/api/live_events/195/start'));
+    assert(testData.sendRequest.calledWith('POST', '/live_events/195/start'));
   });
 
   it('stopEvent should send request to stop event', () => {
@@ -59,7 +59,7 @@ describe('LiveEvent', () => {
     const result = testData.instance.stopEvent(195);
 
     assert.equal(result, testData.retval);
-    assert(testData.sendRequest.calledWith('POST', '/api/live_events/195/stop'));
+    assert(testData.sendRequest.calledWith('POST', '/live_events/195/stop'));
   });
 
   it('cancelEvent should send request to cancel event', () => {
@@ -67,7 +67,7 @@ describe('LiveEvent', () => {
     const result = testData.instance.cancelEvent(195);
 
     assert.equal(result, testData.retval);
-    assert(testData.sendRequest.calledWith('POST', '/api/live_events/195/cancel'));
+    assert(testData.sendRequest.calledWith('POST', '/live_events/195/cancel'));
   });
 
   it('archiveEvent should send request to archive event', () => {
@@ -75,7 +75,7 @@ describe('LiveEvent', () => {
     const result = testData.instance.archiveEvent(195);
 
     assert.equal(result, testData.retval);
-    assert(testData.sendRequest.calledWith('POST', '/api/live_events/195/archive'));
+    assert(testData.sendRequest.calledWith('POST', '/live_events/195/archive'));
   });
 
   it('resetEvent should send request to reset event', () => {
@@ -83,7 +83,7 @@ describe('LiveEvent', () => {
     const result = testData.instance.resetEvent(195);
 
     assert.equal(result, testData.retval);
-    assert(testData.sendRequest.calledWith('POST', '/api/live_events/195/reset'));
+    assert(testData.sendRequest.calledWith('POST', '/live_events/195/reset'));
   });
 
   it('muteEvent should send request to mute event', () => {
@@ -91,7 +91,7 @@ describe('LiveEvent', () => {
     const result = testData.instance.muteEvent(195);
 
     assert.equal(result, testData.retval);
-    assert(testData.sendRequest.calledWith('POST', '/api/live_events/195/mute_audio'));
+    assert(testData.sendRequest.calledWith('POST', '/live_events/195/mute_audio'));
   });
 
   it('unmuteEvent should send request to unmute event', () => {
@@ -99,7 +99,7 @@ describe('LiveEvent', () => {
     const result = testData.instance.unmuteEvent(195);
 
     assert.equal(result, testData.retval);
-    assert(testData.sendRequest.calledWith('POST', '/api/live_events/195/unmute_audio'));
+    assert(testData.sendRequest.calledWith('POST', '/live_events/195/unmute_audio'));
   });
 
   it('adjustAudioGain should send request to adjust audio gain with proper parameter', () => {
@@ -107,7 +107,7 @@ describe('LiveEvent', () => {
     const result = testData.instance.adjustAudioGain(195, 3);
 
     assert.equal(result, testData.retval);
-    assert(testData.sendRequest.calledWith('POST', '/api/live_events/195/adjust_audio_gain', null, {'gain': 3}));
+    assert(testData.sendRequest.calledWith('POST', '/live_events/195/adjust_audio_gain', null, {'gain': 3}));
   });
 
   it('eventPriority should send request to get priority of given event', () => {
@@ -115,7 +115,7 @@ describe('LiveEvent', () => {
     const result = testData.instance.eventPriority(199);
 
     assert.equal(result, testData.retval);
-    assert(testData.sendRequest.calledWith('GET', '/api/live_events/199/priority'));
+    assert(testData.sendRequest.calledWith('GET', '/live_events/199/priority'));
   });
 
   it('setEventPriority should send request to set the priority of given event', () => {
@@ -123,7 +123,7 @@ describe('LiveEvent', () => {
     const result = testData.instance.setEventPriority(199, 1);
 
     assert.equal(result, testData.retval);
-    assert(testData.sendRequest.calledWith('POST', '/api/live_events/199/priority', null, {'priority': 1}));
+    assert(testData.sendRequest.calledWith('POST', '/live_events/199/priority', null, {'priority': 1}));
   });
 
   it('eventProgressPreview should return the jpg url', () => {
@@ -138,6 +138,6 @@ describe('LiveEvent', () => {
     const result = testData.instance.activateInput(195, 465);
 
     assert.equal(result, testData.retval);
-    assert(testData.sendRequest.calledWith('POST', '/api/live_events/195/activate_input', null, {'input_id': 465}));
+    assert(testData.sendRequest.calledWith('POST', '/live_events/195/activate_input', null, {'input_id': 465}));
   });
 });

--- a/test/resource-test.js
+++ b/test/resource-test.js
@@ -4,9 +4,7 @@ import sinon from 'sinon';
 
 describe('Resource', () => {
   const resourceName = 'stuff';
-  const resourceUrl = '/api/stuff';
-  const dummyVersion = '2.14'
-  const versionedUrl = `/api/${dummyVersion}/stuff`;
+  const resourceUrl = '/stuff';
   const retval = {key: 'value'};
   let client = {};
 
@@ -23,31 +21,12 @@ describe('Resource', () => {
     assert(client.sendRequest.calledWith('POST', resourceUrl, null, data))
   });
 
-  it('create with version', () => {
-    client.version = dummyVersion;
-    const resource = new Resource(client, resourceName);
-    const data = {name: 'Some stuff', description: 'Best stuff ever!'};
-    const result = resource.create(data);
-
-    assert.equal(result, retval);
-    assert(client.sendRequest.calledWith('POST', versionedUrl, null, data))
-  });
-
   it('retrieve', () => {
     const resource = new Resource(client, resourceName);
     const result = resource.retrieve(10);
 
     assert.equal(result, retval);
     assert(client.sendRequest.calledWith('GET', `${resourceUrl}/10`))
-  });
-
-  it('retrieve with version', () => {
-    client.version = dummyVersion;
-    const resource = new Resource(client, resourceName);
-    const result = resource.retrieve(10);
-
-    assert.equal(result, retval);
-    assert(client.sendRequest.calledWith('GET', `${versionedUrl}/10`))
   });
 
   it('update', () => {
@@ -59,16 +38,6 @@ describe('Resource', () => {
     assert(client.sendRequest.calledWith('PUT', `${resourceUrl}/10`, null, data))
   });
 
-  it('update with version', () => {
-    client.version = dummyVersion;
-    const resource = new Resource(client, resourceName);
-    const data = {description: 'Stuff number 10 (is this binary or decimal?)'}
-    const result = resource.update(10, data);
-
-    assert.equal(result, retval);
-    assert(client.sendRequest.calledWith('PUT', `${versionedUrl}/10`, null, data))
-  });
-
   it('delete', () => {
     const resource = new Resource(client, resourceName);
     const result = resource.delete(10);
@@ -77,29 +46,11 @@ describe('Resource', () => {
     assert(client.sendRequest.calledWith('DELETE', `${resourceUrl}/10`))
   });
 
-  it('delete with version', () => {
-    client.version = dummyVersion;
-    const resource = new Resource(client, resourceName);
-    const result = resource.delete(10);
-
-    assert.equal(result, retval);
-    assert(client.sendRequest.calledWith('DELETE', `${versionedUrl}/10`))
-  });
-
   it('list', () => {
     const resource = new Resource(client, resourceName);
     const result = resource.list({page: 1});
 
     assert.equal(result, retval);
     assert(client.sendRequest.calledWith('GET', resourceUrl, {page: 1}))
-  });
-
-  it('list with version', () => {
-    client.version = dummyVersion;
-    const resource = new Resource(client, resourceName);
-    const result = resource.list({page: 1});
-
-    assert.equal(result, retval);
-    assert(client.sendRequest.calledWith('GET', versionedUrl, {page: 1}))
   });
 });


### PR DESCRIPTION
Even though the user guide says:

> Although it is recommended that the API version prefix is included in all REST endpoints, omitting the prefix will assume the most current up-to-date API version

If you make a GET request to an endpoint like `/api/v2.17.3.0/devices` the response will be:

```
<?xml version="1.0" encoding="UTF-8"?>
<errors>
    <error>API versioning only supported for POST and PUT requests</error>
</errors>
```

The critical line in the user guide is:

> Responses from the server will always be formed according to the current API version.

Paraphrasing: regardless of what version number you include in your request path, the server is going to respond with the current API's schema. As a result, it only makes sense to support versioning for endpoints where you're sending data to the server. You can send data in 2.15's schema to a 2.17 server, for example, but once you upgrade a server to 2.17, you're only going to get 2.17's schema back.

Anyway, this PR changes `sendRequest` to reflect this reality and removes a lot of code made redundant by this change.

It also removes `generatePreview` from the device API. This was never a supported API endpoint and is not mentioned in the user guide. Removing it also allows for consistency in the URL paths, because every other endpoint supported by this client follows the same pattern. 